### PR TITLE
Properly format `karte` stack traces in graylog

### DIFF
--- a/karte/helm/karte/values.yaml
+++ b/karte/helm/karte/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: 543343501704.dkr.ecr.us-west-2.amazonaws.com/ai.asserts.karte
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
@@ -170,17 +170,28 @@ fluent-bit:
       [FILTER]
           Name                    kubernetes
           Match                   kube.*
-          Merge_Log_Key           log
+          Merge_Log_Key           log_processed
           Merge_Log               On
-          Keep_Log                Off
+          Keep_Log                On
           Annotations             Off
           Labels                  Off
           K8S-Logging.Parser On
           K8S-Logging.Exclude On
       [FILTER]
           Name                nest
+          Match               *
+          Operation lift
+          Nested_under log_processed
+          Add_prefix log_proc_
+      # Filter out log messages that didn't come in the JSON format used by karte, in which the short log
+      # message is in the `message` property.
+      [FILTER]
+          Name                grep
+          Match               *
+          regex               log_proc_message .+
+      [FILTER]
+          Name                nest
           Match               kube.*
-          Wildcard            *_name
           Operation lift
           Nested_under kubernetes
           Add_prefix   kubernetes_
@@ -209,4 +220,4 @@ fluent-bit:
           Mode                    tcp
           Gelf_Timestamp_Key      time
           Gelf_Host_Key           stream
-          Gelf_Short_Message_Key  log
+          Gelf_Short_Message_Key  log_proc_message

--- a/karte/karte/app.py
+++ b/karte/karte/app.py
@@ -4,14 +4,21 @@ from random import Random
 
 import requests
 from flask import Flask, request
+from json_log_formatter import JSONFormatter
 from prometheus_flask_exporter import PrometheusMetrics
 from flask_apscheduler import APScheduler
 
 app = Flask(__name__)
 metrics = PrometheusMetrics(app)
 random = Random(1)
+
+log_formatter = JSONFormatter()
+log_handler = logging.StreamHandler()
+log_handler.setFormatter(log_formatter)
 # Turn on logging for outgoing requests to more easily tell where requests are going:
-logging.basicConfig(level=logging.DEBUG)
+# noinspection PyArgumentList
+logging.basicConfig(level=logging.DEBUG, handlers=[log_handler])
+
 scheduler = APScheduler()
 scheduler.init_app(app)
 scheduler.start()

--- a/karte/poetry.lock
+++ b/karte/poetry.lock
@@ -155,6 +155,14 @@ MarkupSafe = ">=0.23"
 i18n = ["Babel (>=0.8)"]
 
 [[package]]
+name = "json-log-formatter"
+version = "0.3.1"
+description = "JSON log formatter"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "markupsafe"
 version = "1.1.1"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -345,7 +353,7 @@ watchdog = ["watchdog"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "364d502e5bcdfbf150df0b9d0d17c7a4fcb9eae0fe647b4439b17fe80dbef0f6"
+content-hash = "e5d79494bb1319969f11c1d46a5d34793673ff8efc8431d2804477bd230fb9d7"
 
 [metadata.files]
 apscheduler = [
@@ -398,6 +406,9 @@ itsdangerous = [
 jinja2 = [
     {file = "Jinja2-2.11.2-py2.py3-none-any.whl", hash = "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"},
     {file = "Jinja2-2.11.2.tar.gz", hash = "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0"},
+]
+json-log-formatter = [
+    {file = "JSON-log-formatter-0.3.1.tar.gz", hash = "sha256:03029bddba697d2f6c81419a80f1c58d3a89ae715336c6a88b370e7d2c983198"},
 ]
 markupsafe = [
     {file = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"},

--- a/karte/pyproject.toml
+++ b/karte/pyproject.toml
@@ -11,6 +11,7 @@ prometheus-flask-exporter = "^0.18.1"
 gunicorn = "^20.0.4"
 requests = "^2.25.1"
 Flask-APScheduler = "^1.11.0"
+JSON-log-formatter = "^0.3.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
[ch4661]

Handle multiline log messages such as Python stack traces such that they appear as a single message in graylog. For example, here's what a stack trace looks like now:
<img width="1734" alt="Screen Shot 2021-05-13 at 4 18 42 PM" src="https://user-images.githubusercontent.com/2955685/118200479-ff8bf600-b409-11eb-9e24-ccf480d7c95a.png">

I did this by changing `karte` to product log messages in JSON, and then tweaking the fluent-bit configuration to parse this JSON (which is itself nested within a separate JSON document by Docker's logging system).