### PR TITLE
Add flag to disable prometheus-operator

### DIFF
--- a/karte/helm/karte-umbrella/Chart.yaml
+++ b/karte/helm/karte-umbrella/Chart.yaml
@@ -9,6 +9,7 @@ dependencies:
   - name: kube-prometheus-stack
     version: "17.1.0"
     repository: "https://prometheus-community.github.io/helm-charts"
+    condition: kube-prometheus-stack.enabled
   - name: fluent-bit
     version: "0.12.3"
     repository: "https://fluent.github.io/helm-charts"

--- a/karte/helm/karte-umbrella/values.yaml
+++ b/karte/helm/karte-umbrella/values.yaml
@@ -18,6 +18,7 @@ karte:
   problemStateEnabled: true
 
 kube-prometheus-stack:
+  enabled: false
   namespaceOverride: "prometheus"
 
   kube-state-metrics:


### PR DESCRIPTION
I have not disabled this yet but have a PR to run a prom-operator via argo at https://github.com/asserts/stage/pull/2/files.